### PR TITLE
Fix logic error for computer group check

### DIFF
--- a/Install-T0.ps1
+++ b/Install-T0.ps1
@@ -570,7 +570,7 @@ if ($null -eq $ComputerGroup){
     }
 } else {
     #The computer group should be a domain local or universal group.
-    if (($ComputerGroup.GroupScope -ne "Universal") -or ($ComputerGroup.GroupScope -ne "Global")){
+    if (-not (($ComputerGroup.GroupScope -eq "Universal") -or ($ComputerGroup.GroupScope -eq "Global"))){
         Write-Host "The group $($ComputerGroup.Name) group scope is not domain local or Universal." -ForegroundColor Yellow
         ContinueOnError
     }


### PR DESCRIPTION
Due to De Morgan's laws the computer group check tried to enforce that the group is universal and domain local. Fixed the logic.